### PR TITLE
title タグの削除 (fix #6)

### DIFF
--- a/header.php
+++ b/header.php
@@ -5,7 +5,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 	<meta name="description" content="<?php bloginfo('description'); ?>" />
-	<title><?php wp_title(); ?></title>
 	<!--[if lt IE 9]>
 	<script src="<?php echo esc_url( get_template_directory_uri() ); ?>/src/scripts/html5.js"></script>
 	<![endif]-->


### PR DESCRIPTION
`add_theme_support( 'title-tag' );` は functions.php にありました。
