### PR TITLE
#76 fixed(removed ?>)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -47,5 +47,3 @@ function for_the_future_scripts() {
 }
 
 add_action( 'wp_enqueue_scripts', 'for_the_future_scripts' );
-
-?>


### PR DESCRIPTION
functions.phpの一番最後の余計な?>を削除
