### PR TITLE
#94 スクロールせずにフッターを最下部表示

### DIFF
--- a/src/styles/base/_elements.scss
+++ b/src/styles/base/_elements.scss
@@ -3,6 +3,9 @@
 body {
 	font-family: 'Noto Sans', 'Noto Sans Japanese', sans-serif;
 	font-size: 18px;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 	color: $body-color;
 	margin: 0 auto;
 	min-height: 100vh;


### PR DESCRIPTION
#94

> - コンテンツが少ししかない時にfooterをブラウザ下部に固定させようとしていますが、footer分のスクロールが発生します。(こういう実装やったことあるんですけど、見つからない・・・)
