### PR TITLE
#132 .nav-btn の padding

### DIFF
--- a/src/styles/modules/_nav-btn.scss
+++ b/src/styles/modules/_nav-btn.scss
@@ -11,7 +11,7 @@
 	border: none;
 	background: none;
 	outline: none;
-	text-align: center;
+	padding: 2px 0 3px;
 
 	.nav-btn-line {
 		top: 0;


### PR DESCRIPTION
### 変更点
#132 Mobile Safari におけるMENUの文字の位置

![simulator screen shot 2016 03 27 0 12 56](https://cloud.githubusercontent.com/assets/5253290/14060733/b4dd2170-f3b0-11e5-83fc-d9a8ba9077c8.png)
### 関連するissue
#132

---
- [ ] All tests passed

close #132
