### PR TITLE
fix #191

### DIFF
--- a/src/styles/modules/_thumbnail-title.scss
+++ b/src/styles/modules/_thumbnail-title.scss
@@ -22,6 +22,7 @@
 		opacity: 0;
 		height: 0;
 		margin: 0;
+		overflow: hidden;
 	}
 	.thumbnail-title-wrapper {
 		position: relative;


### PR DESCRIPTION
### 変更点

`.thumbnail-title-wrapper` からはみ出ていたタイトルテキスト（`.thumbnail-title`）に`overflow: hidden;` 付与
### 関連するissue

---
- [ ] All tests passed
