### PR TITLE
ul - square、ol - decimal　に修正 #221

### DIFF
--- a/src/styles/base/_elements.scss
+++ b/src/styles/base/_elements.scss
@@ -91,11 +91,11 @@ p {
 	margin-bottom: 28px;
 }
 
-ul li {
+ul > li {
 	list-style-type: square;
 }
 
-ol li {
+ol > li {
 	list-style-type: decimal;
 }
 


### PR DESCRIPTION
### 変更点

ul、olとも直下のliにスタイルをつけるように変更。
### 関連するissue

---
- [ ] All tests passed
