### PR TITLE
テーマのタグをスラッグに修正 #204

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -10,7 +10,7 @@ Version: 1.0.0
 License: GNU General Public License v3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Text Domain: for-the-future
-Tags: Black,Gray,White,Light,Fluid Layout,Responsive Layout,One Column,Custom Background,Custom Menu,Featured Image Header,Featured Images,Sticky Post
+Tags: black,gray,white,light,fluid-layout,responsive-layout,one-column,custom-background,custom-menu,featured-image-header,featured-images,sticky-post
 */
 @import "variables";
 @import "base/normalize";


### PR DESCRIPTION
### 変更点

テーマのタグをスラッグに修正
https://make.wordpress.org/themes/handbook/review/required/theme-tags/
### 関連するissue

---
- [ ] All tests passed
