### PR TITLE
投稿のメタ情報の幅を40% -> 80%に #232

### DIFF
--- a/src/styles/modules/_entry.scss
+++ b/src/styles/modules/_entry.scss
@@ -27,7 +27,7 @@
 		margin: 40px auto;
 	}
 	.entry-meta {
-		max-width: 40%;
+		max-width: 80%;
 		margin: 0 auto;
 		time {
 			display: block;


### PR DESCRIPTION
Fix #232 
### 変更点
### 関連するissue

---
- [x] All tests passed
