### PR TITLE
sticky対応

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,36 +15,39 @@
 		<div class="l-grid">
 			<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 				<div class="l-grid-col l-grid-col--1-2 l-grid-col--medium-1-4 l-grid-col--large-1-4">
-					<article class="thumbnail-title-wrapper" <?php post_class(); ?>>
-
-						<a href="<?php the_permalink(); ?>">
-							<?php
-							if( has_post_thumbnail() ) :?>
-								<div class="square-thumbnail" style="background-image: url('<?php echo get_the_post_thumbnail_url();?>');">
-									<?php the_post_thumbnail();?>
-								</div>
+					<article class="thumbnail-title-wrapper">
+						<div <?php post_class(); ?>><!-- div for post_class -->
+							<a href="<?php the_permalink(); ?>">
 								<?php
-							else : ?>
-								<div class="square-thumbnail" style="background-image: url('<?php echo esc_url( get_template_directory_uri() ); ?>/images/img_noimg.png');">
-									<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/images/img_noimg.png" alt="" />
-								</div>
-								<?php
-							endif;
-							?>
-							<?php
-								$title = esc_html( get_the_title() );
-								if ( mb_strlen($title) > 160 ) :
-									$title = mb_substr($title,0,160).'...';
+								if( has_post_thumbnail() ) :?>
+									<div class="square-thumbnail" style="background-image: url('<?php echo get_the_post_thumbnail_url();?>');">
+										<?php the_post_thumbnail();?>
+									</div>
+									<?php
+								else : ?>
+									<div class="square-thumbnail" style="background-image: url('<?php echo esc_url( get_template_directory_uri() ); ?>/images/img_noimg.png');">
+										<img src="<?php echo esc_url( get_template_directory_uri() ); ?>/images/img_noimg.png" alt="" />
+									</div>
+									<?php
 								endif;
-							?>
-							<h1 class="thumbnail-title">
-								<span class="thumbnail-title-body-wrap">
-									<span class="thumbnail-title-body">
-										<?php echo $title; ?>
+								?>
+								<?php
+									$title = esc_html( get_the_title() );
+									if ( mb_strlen($title) > 160 ) :
+										$title = mb_substr($title,0,160).'...';
+									endif;
+								?>
+								<div class="sticky-label"><i class="fa fa-heart" aria-hidden="true"></i> STICKY</div>
+								<h1 class="thumbnail-title">
+									<span class="thumbnail-title-body-wrap">
+										<span class="thumbnail-title-body">
+											<?php echo $title; ?>
+										</span>
 									</span>
-								</span>
-							</h1>
-						</a>
+								</h1>
+								<div class="sticky-icon"><i class="fa fa-heart" aria-hidden="true"></i><br><span>STICKY</span></div><!-- for sticky -->
+							</a>
+						</div>
 					</article>
 				</div>
 

--- a/src/styles/modules/_sticky.scss
+++ b/src/styles/modules/_sticky.scss
@@ -1,0 +1,38 @@
+.sticky-icon,
+.sticky-label {
+	display: none;
+}
+
+.sticky .sticky-label {
+	display: inline;
+	color: #fff;
+	background: #000;
+	font-size: 12px;
+	padding: 2px 4px;
+	margin-right: 10px;
+}
+
+@media #{$large-up} {
+	.sticky .sticky-label {
+		display: none;
+	}
+	.sticky .sticky-icon {
+		display: block;
+	}
+	.sticky {
+		position: relative;
+		.sticky-icon {
+			position: absolute;
+			bottom: 20px;
+			text-align: center;
+			left: 0;
+			right: 0;
+			color: #fff;
+			line-height: 0.7;
+			span {
+				font-size: 9px;
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
### 変更点
- index.php

class="thumbnail-title-wrapper”と競合してpost_classを出力できてなかったので、post_class出力用divを別途追加。

after擬似要素で表示しようとしたが表示する要素が二つ(ハートアイコンとSTICKYの文字列)あってフォントサイズなど細かな調整が難しかったので、stickyクラスがない時は非表示になる要素div.sticky-iconを追加。

スマホ用div.sticky-labelを追加。
- _sticky.scss

新規追加
### 関連するissue
#265

---
- [ ] All tests passed
