### PR TITLE
タブレット以下のsticky時にサムネイルとラベルの間に隙間が空いていたので調整

### DIFF
--- a/index.php
+++ b/index.php
@@ -37,7 +37,7 @@
 										$title = mb_substr($title,0,160).'...';
 									endif;
 								?>
-								<div class="sticky-label"><i class="fa fa-heart" aria-hidden="true"></i> STICKY</div>
+								<div class="sticky-label"><i class="fa fa-heart" aria-hidden="true"></i>&nbsp;STICKY</div><!-- for sticky -->
 								<h1 class="thumbnail-title">
 									<span class="thumbnail-title-body-wrap">
 										<span class="thumbnail-title-body">

--- a/src/styles/modules/_sticky.scss
+++ b/src/styles/modules/_sticky.scss
@@ -4,12 +4,13 @@
 }
 
 .sticky .sticky-label {
-	display: inline;
+	display: block;
 	color: #fff;
 	background: #000;
 	font-size: 12px;
 	padding: 2px 4px;
 	margin-right: 10px;
+	width: 5em;
 }
 
 @media #{$large-up} {


### PR DESCRIPTION
### 変更点

タブレット以下のsticky時にサムネイルとラベルの間に隙間が空いていたので調整
(inline, inline-blockでこの問題が発生していたのでblock扱いに変更)
### 関連するissue
#265

---
- [ ] All tests passed
