### PR TITLE
ハードコーディングになっている単語を翻訳可能に修正。

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -4,7 +4,7 @@ if ( post_password_required() ) {
 }
 ?>
 <section class="comments-area">
-	<h1 class="comments-title">Comments</h1>
+	<h1 class="comments-title"><?php _e( 'Comments', 'for-the-future' ); ?></h1>
 
 	<?php if ( have_comments() ) : ?>
 

--- a/header.php
+++ b/header.php
@@ -23,7 +23,7 @@
 				</a></h1>
 			<button type="button" class="nav-btn">
 				<div class="nav-btn-line"></div>
-				<span class="menu">MENU</span>
+				<span class="menu"><?php _e( 'MENU', 'for-the-future' ); ?></span>
 			</button>
 			<nav class="gnav" data-gnav aria-expanded="false">
 				<?php get_search_form(); ?>

--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@
 										$title = mb_substr($title,0,160).'...';
 									endif;
 								?>
-								<div class="sticky-label"><i class="fa fa-heart" aria-hidden="true"></i>&nbsp;STICKY</div><!-- for sticky -->
+								<div class="sticky-label"><i class="fa fa-heart" aria-hidden="true"></i>&nbsp;<?php _e( 'STICKY', 'for-the-future' ); ?>STICKY</div><!-- for sticky -->
 								<h1 class="thumbnail-title">
 									<span class="thumbnail-title-body-wrap">
 										<span class="thumbnail-title-body">
@@ -41,7 +41,7 @@
 										</span>
 									</span>
 								</h1>
-								<div class="sticky-icon"><i class="fa fa-heart" aria-hidden="true"></i><br><span>STICKY</span></div><!-- for sticky -->
+								<div class="sticky-icon"><i class="fa fa-heart" aria-hidden="true"></i><br><span><?php _e( 'STICKY', 'for-the-future' ); ?></span></div><!-- for sticky -->
 							</a>
 						</div>
 					</article>
@@ -56,8 +56,8 @@
 				<div class="index-nav-links">
 					<?php
 					$args = array(
-						'prev_text' => '<i class="fa fa-angle-left"></i> PREV',
-						'next_text' => 'NEXT <i class="fa fa-angle-right"></i>',
+						'prev_text' => '<i class="fa fa-angle-left"></i>' . __( 'PREV', 'for-the-future' ),
+						'next_text' => __( 'NEXT', 'for-the-future' ) . '<i class="fa fa-angle-right"></i>'
 					);
 					echo the_posts_pagination( $args );
 					?>

--- a/singular.php
+++ b/singular.php
@@ -9,8 +9,8 @@
 
 		if ( is_single() ) :
 			the_post_navigation( array(
-				'prev_text' => '<span title="%title" ><i class="fa fa-angle-left"></i> PREV</span>',
-				'next_text' => 'NEXT <i class="fa fa-angle-right"></i>',
+				'prev_text' => '<span title="%title" ><i class="fa fa-angle-left"></i>' . __( 'PREV', 'for-the-future') . '</span>',
+				'next_text' => __( 'NEXT', 'for-the-future' ) . '<i class="fa fa-angle-right"></i>',
 			) );
 		endif;
 


### PR DESCRIPTION
### 変更点
MENU、NEXT、PREVなどハードコーディングになっている単語を翻訳可能に修正。#283

### 関連するissue

---
- [ ] All tests passed

