### PR TITLE
Fix #294 Fix #303

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,7 +33,9 @@
 										$title = mb_substr($title,0,160).'...';
 									endif;
 								?>
-								<div class="sticky-label"><i class="fa fa-heart" aria-hidden="true"></i>&nbsp;<?php _e( 'STICKY', 'for-the-future' ); ?>STICKY</div><!-- for sticky -->
+								<?php if( is_sticky() ) : ?>
+								<div class="sticky-label"><i class="fa fa-heart" aria-hidden="true"></i><br><span><?php _e( 'STICKY', 'for-the-future' ); ?></span></div><!-- for sticky -->
+								<?php endif; ?>
 								<h1 class="thumbnail-title">
 									<span class="thumbnail-title-body-wrap">
 										<span class="thumbnail-title-body">
@@ -41,7 +43,6 @@
 										</span>
 									</span>
 								</h1>
-								<div class="sticky-icon"><i class="fa fa-heart" aria-hidden="true"></i><br><span><?php _e( 'STICKY', 'for-the-future' ); ?></span></div><!-- for sticky -->
 							</a>
 						</div>
 					</article>

--- a/src/styles/modules/_sticky.scss
+++ b/src/styles/modules/_sticky.scss
@@ -1,28 +1,23 @@
-.sticky-icon,
-.sticky-label {
-	display: none;
-}
-
-.sticky .sticky-label {
-	display: block;
-	color: #fff;
-	background: #000;
-	font-size: 12px;
-	padding: 2px 4px;
-	margin-right: 10px;
-	width: 5em;
+.sticky {
+	.sticky-label {
+		color: #fff;
+		background: #000;
+		font-size: 12px;
+		padding: 2px 4px;
+		margin-right: 10px;
+		width: 5em;
+		br {
+			display: none;
+		}
+		i {
+			margin-right: .3em;
+		}
+	}
 }
 
 @media #{$large-up} {
-	.sticky .sticky-label {
-		display: none;
-	}
-	.sticky .sticky-icon {
-		display: block;
-	}
 	.sticky {
-		position: relative;
-		.sticky-icon {
+		.sticky-label {
 			position: absolute;
 			bottom: 20px;
 			text-align: center;
@@ -30,10 +25,21 @@
 			right: 0;
 			color: #fff;
 			line-height: 0.7;
+			background: none;
+			padding: 0;
+			margin: 0;
+			width: auto;
+			font-size: 100%;
+			z-index: 1;
 			span {
 				font-size: 9px;
+			}
+			br {
+				display: block;
+			}
+			i {
+				margin-right: 0;
 			}
 		}
 	}
 }
-


### PR DESCRIPTION
### 変更点
PCは `.sticky-icon`、SPは `.sticky-label` と分けられていたのを `.sticky-label` の1つだけに。
CSS で表示箇所の切り替えをしました。

```php
<?php if( is_sticky() ) : ?>
<div class="sticky-label"><i class="fa fa-heart" aria-hidden="true"></i><br><span><?php _e( 'STICKY', 'for-the-future' ); ?></span></div><!-- for sticky -->
<?php endif; ?>
<h1 class="thumbnail-title">
	<span class="thumbnail-title-body-wrap">
		<span class="thumbnail-title-body">
			<?php echo $title; ?>
		</span>
	</span>
</h1>
```

### 関連するissue

#303 
#294 

---
- [ ] All tests passed

