### PR TITLE
Fix #313

### DIFF
--- a/gulp/tasks/dist.js
+++ b/gulp/tasks/dist.js
@@ -27,7 +27,8 @@ gulp.task('copy', function() {
 				"!composer.json",
 				"!bower.json",
 				"!package.json",
-				"!./node_modules/**/*.*"
+				"!./node_modules/**/*.*",
+				"!./screenshots/**/*.*"
 			],
 			{ base: './' }
 		)


### PR DESCRIPTION
### 変更点

gulp/tasks/dist.js に /screenshots フォルダコピーしないようにタスクを修正いたしました

### 関連するissue

#313 

---
- [ ] All tests passed
